### PR TITLE
Relax poise-python version dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file is used to list changes made in each version of the letsencryptaws cookbook.
 
+## 1.0.6
+- [mattlqx] - Loosen poise-python version dependency.
+
+## 1.0.5
+- [mattlqx] - Switch backend s3 resource to `remote_file_s3`
+
 ## 1.0.4
 - [mattlqx] - Use `--cert-name` attribute for certbot.
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 
 gem 'aws-sdk-route53'
 gem 'berkshelf'
-gem 'chef', '~> 13.6.4'
+gem 'chef', '~> 13.8.5'
 gem 'chefspec', '~> 7.1.0'
 gem 'foodcritic', '~> 12.2.2'
 gem 'kitchen-transport-rsync'

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'matt@lqx.net'
 license          'MIT'
 description      'Procures Let\'s Encrypt SSL certificates for Route 53-hosted domains'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.0.5'
+version          '1.0.6'
 
 supports     'ubuntu' if respond_to?(:supports)
 chef_version '>= 12'
@@ -14,5 +14,5 @@ chef_version '>= 12'
 issues_url 'https://github.com/mattlqx/cookbook-letsencryptaws/issues' if respond_to?(:issues_url)
 source_url 'https://github.com/mattlqx/cookbook-letsencryptaws' if respond_to?(:source_url)
 
-depends 'poise-python', '~> 1.6.0'
+depends 'poise-python', '~> 1.6'
 depends 'remote_file_s3', '~> 1.0.5'


### PR DESCRIPTION
Version < 1.7.0 of poise-python contains an issue dealing with pip >10. Relax the version dependency so that 1.7 can be used.