### PR TITLE
install idna 2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file is used to list changes made in each version of the letsencryptaws cookbook.
 
+## 1.0.8
+- [mattlqx] - Add explicit python package version idna 2.6. Yay constaints.
+
 ## 1.0.7
 - [mattlqx] - Bump `cryptography` module version.
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'matt@lqx.net'
 license          'MIT'
 description      'Procures Let\'s Encrypt SSL certificates for Route 53-hosted domains'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.0.7'
+version          '1.0.8'
 
 supports     'ubuntu' if respond_to?(:supports)
 chef_version '>= 12'

--- a/recipes/certbot.rb
+++ b/recipes/certbot.rb
@@ -22,6 +22,11 @@ python_package 'cryptography' do
   action :upgrade
 end
 
+python_package 'idna' do
+  version '2.6'
+  action :upgrade
+end
+
 python_package 'certbot'
 python_package 'awscli'
 


### PR DESCRIPTION
Current `requests` dependencies appear to require a specific constaint of `idna<2.7,>=2.5`.