### PR TITLE
ignore README file in live directory when considering certs

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'matt@lqx.net'
 license          'MIT'
 description      'Procures Let\'s Encrypt SSL certificates for Route 53-hosted domains'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.1.1'
+version          '1.1.2'
 
 supports     'ubuntu' if respond_to?(:supports)
 chef_version '>= 12'

--- a/recipes/certbot.rb
+++ b/recipes/certbot.rb
@@ -105,6 +105,7 @@ ruby_block 'remove unrequested certificates' do
   block do
     live_certs = []
     Dir.glob("#{node['letsencryptaws']['config_dir']}/live/*") do |fn|
+      next if fn == 'README'
       live_certs << ::File.basename(fn.sub(/-\d{4}$/, ''))
     end
     certs_to_delete = live_certs - certs_needed.keys.map { |cn| cn.sub('*', 'star') }


### PR DESCRIPTION
Looks like recently a certbot update placed a README in the live directory that gets globbed for certificate names. 