### PR TITLE
bump certbot and crpytography versions, source poise-python from enova

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -5,3 +5,4 @@ source 'https://supermarket.chef.io'
 metadata
 
 cookbook 'letsencryptaws_test', path: 'test/cookbooks/letsencryptaws_test'
+cookbook 'poise-python', git: 'https://github.com/enova/enova-python.git', tag: 'v1.7.1'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This file is used to list changes made in each version of the letsencryptaws cookbook.
 
+## 1.1.4
+- [mattlqx] - Bump certbot and cryptography version.
+- [mattlqx] - Use enova version of poise-python. See [Berksfile](Berksfile) for how to source this in your environment.
+
+## 1.1.3
+- [mattlqx] - Ignore READMEs in syncing to s3.
+
 ## 1.1.1
 - [mattlqx] - Bump cryptography version to 2.5.
 - [mattlqx] - Pin pip version to 18.0 to prevent poise-python bug.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,7 +5,7 @@ default['letsencryptaws']['config_dir'] = '/mnt/letsencrypt'
 default['letsencryptaws']['ebs_device'] = '/dev/xvdf'
 
 # Software versions
-default['letsencryptaws']['certbot_version'] = '0.26.1'
+default['letsencryptaws']['certbot_version'] = '1.0.0'
 
 # Should test certificates be fetched (beware: non-test certs have ratelimits)
 default['letsencryptaws']['test_certs'] = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'matt@lqx.net'
 license          'MIT'
 description      'Procures Let\'s Encrypt SSL certificates for Route 53-hosted domains'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.1.3'
+version          '1.1.4'
 
 supports     'ubuntu' if respond_to?(:supports)
 chef_version '>= 12'

--- a/recipes/certbot.rb
+++ b/recipes/certbot.rb
@@ -18,7 +18,7 @@ python_runtime '2.7' do
 end
 
 python_package 'cryptography' do
-  version '2.5'
+  version '2.8'
   action :upgrade
 end
 


### PR DESCRIPTION
certbot -> 1.0.0
cryptography -> 2.8