### PR TITLE
lazily evaluate any usage of creds

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer       'Matt Kulka'
 maintainer_email 'matt@lqx.net'
 license          'MIT'
 description      'Procures Let\'s Encrypt SSL certificates for Route 53-hosted domains'
-version          '2.0.0'
+version          '2.0.1'
 
 supports     'ubuntu'
 chef_version '>= 12'

--- a/recipes/certbot.rb
+++ b/recipes/certbot.rb
@@ -111,10 +111,12 @@ certs_needed.each_pair do |domain, sans|
 
   execute "get certificate for #{domain}" do
     command command.join(' ')
-    environment ({
-      'AWS_ACCESS_KEY_ID' => node['aws_access_key_id'] || creds('aws_access_key_id'),
-      'AWS_SECRET_ACCESS_KEY' => node['aws_secret_access_key'] || creds('aws_secret_access_key'),
-    })
+    environment (lazy do
+      {
+        'AWS_ACCESS_KEY_ID' => node['aws_access_key_id'] || creds('aws_access_key_id'),
+        'AWS_SECRET_ACCESS_KEY' => node['aws_secret_access_key'] || creds('aws_secret_access_key'),
+      }
+    end)
     live_stream true
   end
 end
@@ -153,10 +155,12 @@ execute 'sync certificates to s3' do
     "#{node['letsencryptaws']['config_dir']}/live/",
     "s3://#{node['letsencryptaws']['sync_bucket']}/#{node['letsencryptaws']['sync_path']}",
   ].join(' ')
-  environment ({
-    'AWS_ACCESS_KEY_ID' => node['aws_access_key_id'] || creds('aws_access_key_id'),
-    'AWS_SECRET_ACCESS_KEY' => node['aws_secret_access_key'] || creds('aws_secret_access_key'),
-  })
+  environment (lazy do
+    {
+      'AWS_ACCESS_KEY_ID' => node['aws_access_key_id'] || creds('aws_access_key_id'),
+      'AWS_SECRET_ACCESS_KEY' => node['aws_secret_access_key'] || creds('aws_secret_access_key'),
+    }
+  end)
   live_stream true
   only_if "[ -d #{node['letsencryptaws']['config_dir']}/live ]"
   not_if { node['letsencryptaws']['sync_bucket'].nil? }

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -29,8 +29,8 @@ end
 remote_file_s3 ::File.join(node['letsencryptaws']['ssl_cert_dir'], 'default.crt') do
   remote_path "/#{node['letsencryptaws']['sync_path']}/default-ssl/default.crt"
   bucket node['letsencryptaws']['sync_bucket']
-  aws_access_key_id node['aws_access_key_id'] || creds('aws_access_key_id')
-  aws_secret_access_key node['aws_secret_access_key'] || creds('aws_secret_access_key')
+  aws_access_key_id lazy { node['aws_access_key_id'] || creds('aws_access_key_id') }
+  aws_secret_access_key lazy { node['aws_secret_access_key'] || creds('aws_secret_access_key') }
   owner node['letsencryptaws']['ssl_owner']
   group node['letsencryptaws']['ssl_group']
   mode '644'
@@ -40,8 +40,8 @@ end
 remote_file_s3 ::File.join(node['letsencryptaws']['ssl_cert_dir'], 'default.ca') do
   remote_path "/#{node['letsencryptaws']['sync_path']}/default-ssl/ca.crt"
   bucket node['letsencryptaws']['sync_bucket']
-  aws_access_key_id node['aws_access_key_id'] || creds('aws_access_key_id')
-  aws_secret_access_key node['aws_secret_access_key'] || creds('aws_secret_access_key')
+  aws_access_key_id lazy { node['aws_access_key_id'] || creds('aws_access_key_id') }
+  aws_secret_access_key lazy { node['aws_secret_access_key'] || creds('aws_secret_access_key') }
   owner node['letsencryptaws']['ssl_owner']
   group node['letsencryptaws']['ssl_group']
   mode '644'
@@ -51,8 +51,8 @@ end
 remote_file_s3 ::File.join(node['letsencryptaws']['ssl_key_dir'], 'default.key') do
   remote_path "/#{node['letsencryptaws']['sync_path']}/default-ssl/default.key"
   bucket node['letsencryptaws']['sync_bucket']
-  aws_access_key_id node['aws_access_key_id'] || creds('aws_access_key_id')
-  aws_secret_access_key node['aws_secret_access_key'] || creds('aws_secret_access_key')
+  aws_access_key_id lazy { node['aws_access_key_id'] || creds('aws_access_key_id') }
+  aws_secret_access_key lazy { node['aws_secret_access_key'] || creds('aws_secret_access_key') }
   owner node['letsencryptaws']['ssl_owner']
   group node['letsencryptaws']['ssl_group']
   mode '640'
@@ -81,8 +81,8 @@ node['letsencryptaws']['certs'].each_pair do |domain, _sans|
   remote_file_s3 ::File.join(node['letsencryptaws']['ssl_cert_dir'], "#{domain}.crt") do
     remote_path "/#{node['letsencryptaws']['sync_path']}/#{domain}/cert.pem"
     bucket node['letsencryptaws']['sync_bucket']
-    aws_access_key_id node['aws_access_key_id'] || creds('aws_access_key_id')
-    aws_secret_access_key node['aws_secret_access_key'] || creds('aws_secret_access_key')
+    aws_access_key_id lazy { node['aws_access_key_id'] || creds('aws_access_key_id') }
+    aws_secret_access_key lazy { node['aws_secret_access_key'] || creds('aws_secret_access_key') }
     owner node['letsencryptaws']['ssl_owner']
     group node['letsencryptaws']['ssl_group']
     mode '644'
@@ -94,8 +94,8 @@ node['letsencryptaws']['certs'].each_pair do |domain, _sans|
   remote_file_s3 ::File.join(node['letsencryptaws']['ssl_cert_dir'], "#{domain}.ca") do
     remote_path "/#{node['letsencryptaws']['sync_path']}/#{domain}/chain.pem"
     bucket node['letsencryptaws']['sync_bucket']
-    aws_access_key_id node['aws_access_key_id'] || creds('aws_access_key_id')
-    aws_secret_access_key node['aws_secret_access_key'] || creds('aws_secret_access_key')
+    aws_access_key_id lazy { node['aws_access_key_id'] || creds('aws_access_key_id') }
+    aws_secret_access_key lazy { node['aws_secret_access_key'] || creds('aws_secret_access_key') }
     owner node['letsencryptaws']['ssl_owner']
     group node['letsencryptaws']['ssl_group']
     mode '644'
@@ -107,8 +107,8 @@ node['letsencryptaws']['certs'].each_pair do |domain, _sans|
   remote_file_s3 ::File.join(node['letsencryptaws']['ssl_key_dir'], "#{domain}.key") do
     remote_path "/#{node['letsencryptaws']['sync_path']}/#{domain}/privkey.pem"
     bucket node['letsencryptaws']['sync_bucket']
-    aws_access_key_id node['aws_access_key_id'] || creds('aws_access_key_id')
-    aws_secret_access_key node['aws_secret_access_key'] || creds('aws_secret_access_key')
+    aws_access_key_id lazy { node['aws_access_key_id'] || creds('aws_access_key_id') }
+    aws_secret_access_key lazy { node['aws_secret_access_key'] || creds('aws_secret_access_key') }
     owner node['letsencryptaws']['ssl_owner']
     group node['letsencryptaws']['ssl_group']
     mode '640'
@@ -158,11 +158,13 @@ node['letsencryptaws']['certs'].each_pair do |domain, _sans|
   execute "generate pkcs12 store for #{domain}" do
     cwd node['letsencryptaws']['ssl_key_dir']
     only_if { node['os'] == 'linux' }
-    command "openssl pkcs12 -export -in #{File.join(node['letsencryptaws']['ssl_cert_dir'], "#{domain}.crt")}" \
-            "  -inkey #{domain}.key -out #{domain}.p12 -name #{domain} " \
-            "  -passout \"pass:#{creds('p12_password')}\"" \
-            "  -CAfile #{File.join(node['letsencryptaws']['ssl_cert_dir'], "#{domain}.ca")}" \
-            "  -CApath #{node['letsencryptaws']['root_ca_dir']} -caname letsencrypt -chain"
+    command lazy {
+              "openssl pkcs12 -export -in #{File.join(node['letsencryptaws']['ssl_cert_dir'], "#{domain}.crt")}" \
+                   "  -inkey #{domain}.key -out #{domain}.p12 -name #{domain} " \
+                   "  -passout \"pass:#{creds('p12_password')}\"" \
+                   "  -CAfile #{File.join(node['letsencryptaws']['ssl_cert_dir'], "#{domain}.ca")}" \
+                   "  -CApath #{node['letsencryptaws']['root_ca_dir']} -caname letsencrypt -chain"
+            }
     action :nothing
     sensitive true
     only_if "openssl verify -CAfile #{::File.join(node['letsencryptaws']['ssl_cert_dir'], "#{domain}.ca")} " \

--- a/recipes/import_keystore.rb
+++ b/recipes/import_keystore.rb
@@ -12,10 +12,12 @@ package node['letsencryptaws']['java_package']
 node['letsencryptaws']['import_keystore'].each_pair do |keystore, domains|
   domains.each do |domain|
     execute "import #{domain} into #{keystore}" do
-      command 'keytool -importkeystore -noprompt' \
-              "  -srckeystore #{File.join(node['letsencryptaws']['ssl_key_dir'], "#{domain}.p12")} " \
-              "  -destkeystore #{keystore} -srcstorepass \"#{creds('p12_password')}\" -deststorepass " \
-              "  \"#{creds('keystore_passwords').fetch(keystore, creds('keystore_passwords')['default'])}\""
+      command lazy {
+                'keytool -importkeystore -noprompt' \
+                     "  -srckeystore #{File.join(node['letsencryptaws']['ssl_key_dir'], "#{domain}.p12")} " \
+                     "  -destkeystore #{keystore} -srcstorepass \"#{creds('p12_password')}\" -deststorepass " \
+                     "  \"#{creds('keystore_passwords').fetch(keystore, creds('keystore_passwords')['default'])}\""
+              }
       subscribes :run, "execute[generate pkcs12 store for #{domain}]", :immediately
       sensitive true
       action :nothing


### PR DESCRIPTION
this better ensures that a user of the cookbook is able to set the aws credentials in `node.run_state`
before its usage in this cookbook.