### PR TITLE
Add aws_session_token for auth with temporary credentials

### DIFF
--- a/recipes/certbot.rb
+++ b/recipes/certbot.rb
@@ -115,6 +115,7 @@ certs_needed.each_pair do |domain, sans|
       {
         'AWS_ACCESS_KEY_ID' => node['aws_access_key_id'] || aws_creds('aws_access_key_id'),
         'AWS_SECRET_ACCESS_KEY' => node['aws_secret_access_key'] || aws_creds('aws_secret_access_key'),
+        'AWS_SESSION_TOKEN' => node['aws_session_token'] || aws_creds('aws_session_token'),
       }
     end)
     live_stream true
@@ -159,6 +160,7 @@ execute 'sync certificates to s3' do
     {
       'AWS_ACCESS_KEY_ID' => node['aws_access_key_id'] || aws_creds('aws_access_key_id'),
       'AWS_SECRET_ACCESS_KEY' => node['aws_secret_access_key'] || aws_creds('aws_secret_access_key'),
+      'AWS_SESSION_TOKEN' => node['aws_session_token'] || aws_creds('aws_session_token'),
     }
   end)
   live_stream true

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -32,6 +32,7 @@ remote_file_s3 ::File.join(node['letsencryptaws']['ssl_cert_dir'], 'default.crt'
   bucket node['letsencryptaws']['sync_bucket']
   aws_access_key_id lazy { node['aws_access_key_id'] || aws_creds('aws_access_key_id') }
   aws_secret_access_key lazy { node['aws_secret_access_key'] || aws_creds('aws_secret_access_key') }
+  aws_session_token lazy { node['aws_session_token'] || aws_creds('aws_session_token') }
   owner node['letsencryptaws']['ssl_owner']
   group node['letsencryptaws']['ssl_group']
   mode '644'
@@ -43,6 +44,7 @@ remote_file_s3 ::File.join(node['letsencryptaws']['ssl_cert_dir'], 'default.ca')
   bucket node['letsencryptaws']['sync_bucket']
   aws_access_key_id lazy { node['aws_access_key_id'] || aws_creds('aws_access_key_id') }
   aws_secret_access_key lazy { node['aws_secret_access_key'] || aws_creds('aws_secret_access_key') }
+  aws_session_token lazy { node['aws_session_token'] || aws_creds('aws_session_token') }
   owner node['letsencryptaws']['ssl_owner']
   group node['letsencryptaws']['ssl_group']
   mode '644'
@@ -54,6 +56,7 @@ remote_file_s3 ::File.join(node['letsencryptaws']['ssl_key_dir'], 'default.key')
   bucket node['letsencryptaws']['sync_bucket']
   aws_access_key_id lazy { node['aws_access_key_id'] || aws_creds('aws_access_key_id') }
   aws_secret_access_key lazy { node['aws_secret_access_key'] || aws_creds('aws_secret_access_key') }
+  aws_session_token lazy { node['aws_session_token'] || aws_creds('aws_session_token') }
   owner node['letsencryptaws']['ssl_owner']
   group node['letsencryptaws']['ssl_group']
   mode '640'
@@ -84,6 +87,7 @@ node['letsencryptaws']['certs'].each_pair do |domain, _sans|
     bucket node['letsencryptaws']['sync_bucket']
     aws_access_key_id lazy { node['aws_access_key_id'] || aws_creds('aws_access_key_id') }
     aws_secret_access_key lazy { node['aws_secret_access_key'] || aws_creds('aws_secret_access_key') }
+    aws_session_token lazy { node['aws_session_token'] || aws_creds('aws_session_token') }
     owner node['letsencryptaws']['ssl_owner']
     group node['letsencryptaws']['ssl_group']
     mode '644'
@@ -97,6 +101,7 @@ node['letsencryptaws']['certs'].each_pair do |domain, _sans|
     bucket node['letsencryptaws']['sync_bucket']
     aws_access_key_id lazy { node['aws_access_key_id'] || aws_creds('aws_access_key_id') }
     aws_secret_access_key lazy { node['aws_secret_access_key'] || aws_creds('aws_secret_access_key') }
+    aws_session_token lazy { node['aws_session_token'] || aws_creds('aws_session_token') }
     owner node['letsencryptaws']['ssl_owner']
     group node['letsencryptaws']['ssl_group']
     mode '644'
@@ -110,6 +115,7 @@ node['letsencryptaws']['certs'].each_pair do |domain, _sans|
     bucket node['letsencryptaws']['sync_bucket']
     aws_access_key_id lazy { node['aws_access_key_id'] || aws_creds('aws_access_key_id') }
     aws_secret_access_key lazy { node['aws_secret_access_key'] || aws_creds('aws_secret_access_key') }
+    aws_session_token lazy { node['aws_session_token'] || aws_creds('aws_session_token') }
     owner node['letsencryptaws']['ssl_owner']
     group node['letsencryptaws']['ssl_group']
     mode '640'


### PR DESCRIPTION
This is needed for short lived AWS credentials that use a session token.  If no session token is provided, returns nil which seems to work for the request as I tested with and without it.