### PR TITLE
Add support for temporary aws credentials file

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -47,6 +47,7 @@ when 'windows'
   default['letsencryptaws']['root_ca_dir'] = 'c:\ssl\certs'
   default['letsencryptaws']['ssl_owner'] = 'SYSTEM'
   default['letsencryptaws']['ssl_group'] = nil
+  default['letsencryptaws']['aws_credentials_file'] = 'C:\chef\awscredentials'
 when 'ubuntu'
   default['letsencryptaws']['ssl_cert_dir'] = '/etc/ssl/certs'
   default['letsencryptaws']['ssl_key_dir'] = '/etc/ssl/private'
@@ -54,4 +55,5 @@ when 'ubuntu'
   default['letsencryptaws']['root_ca_dir'] = '/etc/ssl/certs'
   default['letsencryptaws']['ssl_owner'] = 'root'
   default['letsencryptaws']['ssl_group'] = 'ssl-cert'
+  default['letsencryptaws']['aws_credentials_file'] = '/tmp/aws/credentials'
 end

--- a/libraries/creds.rb
+++ b/libraries/creds.rb
@@ -1,9 +1,15 @@
 # frozen_string_literal: true
 
+require 'json'
+
 def aws_creds(key) # rubocop:disable Metrics/AbcSize
   begin
     node.run_state['letsencryptaws_creds'] ||= \
-      data_bag_item(node['letsencryptaws']['data_bag'], node['letsencryptaws']['data_bag_item']).to_hash
+      if File.exist?(node['letsencryptaws']['aws_credentials_file'])
+        JSON.parse(IO.read(node['letsencryptaws']['aws_credentials_file']))
+      else
+        data_bag_item(node['letsencryptaws']['data_bag'], node['letsencryptaws']['data_bag_item']).to_hash
+      end
   rescue Net::HTTPServerException, Chef::Exceptions::InvalidDataBagName
     node.run_state['letsencryptaws_creds'] = {}
   end

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer       'Matt Kulka'
 maintainer_email 'matt@lqx.net'
 license          'MIT'
 description      'Procures Let\'s Encrypt SSL certificates for Route 53-hosted domains'
-version          '2.0.4'
+version          '2.0.5'
 
 supports     'ubuntu'
 chef_version '>= 12'


### PR DESCRIPTION
Allows me to use a temporary credentials file for local testing when passing SSO credentials via environment vars is not easily automated.