### PR TITLE
allow ebs_device attribute to be nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file is used to list changes made in each version of the letsencryptaws cookbook.
 
+## 2.0.7
+- [mattlqx] - allow `node['letsencryptaws']['ebs_device']` to be nil to prevent mkfs, mount and check.
+
 ## 2.0.5
 - [mattlqx] - version bumps for certbot and cryptography
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer       'Matt Kulka'
 maintainer_email 'matt@lqx.net'
 license          'MIT'
 description      'Procures Let\'s Encrypt SSL certificates for Route 53-hosted domains'
-version          '2.0.6'
+version          '2.0.7'
 
 supports     'ubuntu'
 chef_version '>= 12'

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -14,6 +14,9 @@ describe 'letsencryptaws::default' do
   before do
     allow(Etc).to receive(:getpwnam).and_return(OpenStruct.new(uid: 0))
     allow(Etc).to receive(:getgrnam).and_return(OpenStruct.new(gid: 0))
+    allow(Dir).to receive(:exist?).and_call_original
+    allow(Dir).to receive(:exist?).with('/etc/ssl/certs').and_return(true)
+    allow(Dir).to receive(:exist?).with('/etc/ssl/private').and_return(true)
     stub_data_bag_item('testbag', 'testitem').and_return('p12_password' => 'foo')
   end
 


### PR DESCRIPTION
in circumstances where you might not be using a separate block device or if running the recipe inside a container, allow the ebs device checks to be skipped.
