### PR TITLE
python 3.10.2, unpin cryptography (35+), drop python 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Nodes do not need to be EC2 instances to retrieve or request certificates. All t
 
 ## Requirements
 
-- Python 3 or 2.7 (for certbot and awscli)
+- Python 3
 - certbot ACME client
 - Domain(s) hosted by AWS Route 53
 - S3 bucket for storing/retrieving certificate files

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,9 +5,9 @@ default['letsencryptaws']['config_dir'] = '/mnt/letsencrypt'
 default['letsencryptaws']['ebs_device'] = '/dev/xvdf'
 
 # Software versions
-default['letsencryptaws']['certbot_version'] = '1.18.0'
+default['letsencryptaws']['certbot_version'] = '1.25.0'
 default['letsencryptaws']['certbot_dns_version'] = node['letsencryptaws']['certbot_version']
-default['letsencryptaws']['python_version'] = '3.8.3'
+default['letsencryptaws']['python_version'] = '3.10.2'
 
 # Should aws and certbot in /usr/local/bin be linked to their pyenv paths?
 default['letsencryptaws']['link_pybins'] = true

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer       'Matt Kulka'
 maintainer_email 'matt@lqx.net'
 license          'MIT'
 description      'Procures Let\'s Encrypt SSL certificates for Route 53-hosted domains'
-version          '4.0.0'
+version          '5.0.0'
 
 supports     'ubuntu'
 chef_version '>= 15.3'

--- a/recipes/certbot.rb
+++ b/recipes/certbot.rb
@@ -12,8 +12,6 @@ apt_update 'update' do
   action :periodic
 end
 
-python_major = node['letsencryptaws']['python_version'].split('.').first.to_i
-
 pyenv_install 'system'
 
 pyenv_python node['letsencryptaws']['python_version']
@@ -25,21 +23,8 @@ link '/usr/local/bin/pip' do
   only_if { node['letsencryptaws']['link_pybins'] }
 end
 
-pyenv_pip 'parsedatetime' do
-  version '2.5'
-  only_if do
-    node['letsencryptaws']['python_version'].to_s.start_with?('2.7') || \
-      node['letsencryptaws']['python_version'].to_s == '2'
-  end
-end
-
-pyenv_pip 'cryptography' do
-  version python_major >= 3 ? '3.4.6' : '2.8'
-end
-
-pyenv_pip 'idna' do
-  version python_major >= 3 ? '2.9' : '2.6'
-end
+pyenv_pip 'cryptography'
+pyenv_pip 'idna'
 
 pyenv_pip 'certbot' do
   version node['letsencryptaws']['certbot_version']

--- a/spec/unit/recipes/certbot_spec.rb
+++ b/spec/unit/recipes/certbot_spec.rb
@@ -27,7 +27,7 @@ describe 'letsencryptaws::certbot' do
 
   it 'installs needed packages' do
     expect(chef_run).to install_pyenv_install('system')
-    expect(chef_run).to install_pyenv_python('3.8.3')
+    expect(chef_run).to install_pyenv_python('3.10.2')
     expect(chef_run).to install_pyenv_pip('cryptography')
     expect(chef_run).to install_pyenv_pip('certbot')
     expect(chef_run).to install_pyenv_pip('certbot-dns-route53')


### PR DESCRIPTION
This was failing due to out of date dependencies. cryptography 3.4.0 -> 35.0